### PR TITLE
use cimg/go 1.18 to build binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,8 @@ commands:
 
 jobs:
   test:
-    executor:
-      name: go/default
-      tag: "1.17"
+    docker:
+      - image: cimg/go:1.18
     steps:
       - checkout
       - go/load-cache
@@ -43,9 +42,8 @@ jobs:
       - go/save-cache
 
   build:
-    executor:
-      name: go/default
-      tag: "1.17"
+    docker:
+      - image: cimg/go:1.18
     steps:
       - checkout
       - go/load-cache


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the docker image used to build binaries to include golang 1.18 which includes an updated OpenSSL to resolve CVE.

- Closes #17

## Short description of the changes
- Updates the docker image used to build and test to a newer version of golang

